### PR TITLE
Npmjs OIDC

### DIFF
--- a/.github/workflows/release-publish-npmjs.yaml
+++ b/.github/workflows/release-publish-npmjs.yaml
@@ -2,6 +2,7 @@ name: 'Publish to npmjs on release'
 
 permissions:
   contents: 'read'
+  id-token: 'write'
 
 on:
   release:
@@ -28,6 +29,9 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: 'Update npm'
+        run: 'npm install -g npm@latest'
+
       - name: 'Install dependencies'
         run: 'npm ci'
 
@@ -35,6 +39,4 @@ jobs:
         run: 'npm run build'
 
       - name: 'Publish to npmjs'
-        run: 'npm publish --access public'
-        env:
-          NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'
+        run: 'npm publish'

--- a/.github/workflows/release-publish-npmjs.yaml
+++ b/.github/workflows/release-publish-npmjs.yaml
@@ -39,4 +39,4 @@ jobs:
         run: 'npm run build'
 
       - name: 'Publish to npmjs'
-        run: 'npm publish'
+        run: 'npm publish --access public'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "strapi-plugin-github-actions-dispatch",
-  "version": "0.1.3",
+  "name": "@kaito-tokyo/strapi-plugin-github-actions-dispatcher",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "strapi-plugin-github-actions-dispatch",
-      "version": "0.1.3",
+      "name": "@kaito-tokyo/strapi-plugin-github-actions-dispatcher",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "jsonwebtoken": "^9.0.2"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.4",
+  "version": "0.1.5",
   "keywords": [],
   "type": "commonjs",
   "exports": {


### PR DESCRIPTION
This pull request updates the npm release workflow and bumps the package version. The main changes focus on improving the publishing process to npmjs by updating permissions, ensuring the latest npm is used, and simplifying the publish command.

**Release workflow improvements:**

* Added `id-token: 'write'` permission to the workflow to support secure authentication for publishing.
* Updated the workflow to install the latest version of npm before building and publishing, ensuring compatibility and access to the latest features.
* Simplified the `npm publish` step by removing the `--access public` flag and the explicit `NODE_AUTH_TOKEN` environment variable, likely relying on GitHub's OIDC authentication instead.

**Version update:**

* Bumped the package version from `0.1.4` to `0.1.5` in `package.json` to reflect the new release.