### PR TITLE
Bump version to 0.1.6 and update repository URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kaito-tokyo/strapi-plugin-github-actions-dispatcher",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kaito-tokyo/strapi-plugin-github-actions-dispatcher",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "jsonwebtoken": "^9.0.2"

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "url": "https://github.com/kaito-tokyo/strapi-plugin-github-actions-dispatcher"
   },
   "bugs": {
-    "url": "https://github.com/kaito-tokyo/strapi-plugin-github-actions-dispatch/issues"
+    "url": "https://github.com/kaito-tokyo/strapi-plugin-github-actions-dispatcher/issues"
   },
-  "homepage": "https://github.com/kaito-tokyo/strapi-plugin-github-actions-dispatch#readme",
+  "homepage": "https://github.com/kaito-tokyo/strapi-plugin-github-actions-dispatcher#readme",
   "author": "Kaito Udagawa <umireon@kaito.tokyo>"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.5",
+  "version": "0.1.6",
   "keywords": [],
   "type": "commonjs",
   "exports": {
@@ -47,7 +47,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/kaito-tokyo/strapi-plugin-github-actions-dispatch.git"
+    "url": "https://github.com/kaito-tokyo/strapi-plugin-github-actions-dispatcher"
   },
   "bugs": {
     "url": "https://github.com/kaito-tokyo/strapi-plugin-github-actions-dispatch/issues"


### PR DESCRIPTION
This pull request updates the `package.json` file with minor changes to the package version and repository URL.

* Version bump:
  * Updated the package version from `0.1.5` to `0.1.6` in `package.json`.

* Repository information update:
  * Changed the repository URL to a public HTTPS link and corrected the repository name in `package.json`.Updated package version to 0.1.6 and changed the repository URL in package.json to use the correct HTTPS address for GitHub.